### PR TITLE
Fix raw_data scripts from `usethis` update upstream 

### DIFF
--- a/data-raw/lgr2.R
+++ b/data-raw/lgr2.R
@@ -1,5 +1,6 @@
 library(burnr)
+library(usethis)
 
 lgr2 <- read_fhx('data-raw/lgr2.fhx')
 
-devtools::use_data(lgr2, overwrite = TRUE)
+usethis::use_data(lgr2, overwrite = TRUE)

--- a/data-raw/lgr2_meta.R
+++ b/data-raw/lgr2_meta.R
@@ -1,3 +1,5 @@
+library(usethis)
+
 lgr2_meta <- read.csv('data-raw/lgr2_meta.csv')
 
-devtools::use_data(lgr2_meta, overwrite = TRUE)
+usethis::use_data(lgr2_meta, overwrite = TRUE)

--- a/data-raw/pgm.R
+++ b/data-raw/pgm.R
@@ -1,5 +1,6 @@
 library(burnr)
+library(usethis)
 
 pgm <- read_fhx('data-raw/pgm.fhx')
 
-devtools::use_data(pgm, overwrite = TRUE)
+usethis::use_data(pgm, overwrite = TRUE)

--- a/data-raw/pgm_meta.R
+++ b/data-raw/pgm_meta.R
@@ -1,3 +1,5 @@
+library(usethis)
+
 pgm_meta <- read.csv('data-raw/pgm_meta.csv')
 
-devtools::use_data(pgm_meta, overwrite = TRUE)
+usethis::use_data(pgm_meta, overwrite = TRUE)

--- a/data-raw/pgm_pdsi.R
+++ b/data-raw/pgm_pdsi.R
@@ -1,6 +1,7 @@
-# TXT file downloaded from http://iridl.ldeo.columbia.edu/SOURCES/.LDEO/.TRL/.NADA2004/pdsiatlashtml/pdsiwebdata/1050w_350n_133.txt
+library(usethis)
 
+# TXT file downloaded from http://iridl.ldeo.columbia.edu/SOURCES/.LDEO/.TRL/.NADA2004/pdsiatlashtml/pdsiwebdata/1050w_350n_133.txt
 pdsi_raw <- read.table('data-raw/pgm_pdsi.txt', header = TRUE, row.names = 1)
 pgm_pdsi <- subset(pdsi, select = "RECON")
 
-devtools::use_data(pgm_pdsi, overwrite = TRUE)
+usethis::use_data(pgm_pdsi, overwrite = TRUE)

--- a/data-raw/pgm_pdsi.R
+++ b/data-raw/pgm_pdsi.R
@@ -2,6 +2,6 @@ library(usethis)
 
 # TXT file downloaded from http://iridl.ldeo.columbia.edu/SOURCES/.LDEO/.TRL/.NADA2004/pdsiatlashtml/pdsiwebdata/1050w_350n_133.txt
 pdsi_raw <- read.table('data-raw/pgm_pdsi.txt', header = TRUE, row.names = 1)
-pgm_pdsi <- subset(pdsi, select = "RECON")
+pgm_pdsi <- subset(pdsi_raw, select = "RECON")
 
 usethis::use_data(pgm_pdsi, overwrite = TRUE)


### PR DESCRIPTION
Fix raw_data scripts from `usethis` update upstream. In short, some functions are now in `usethis` not `devtools`.