### PR TITLE
Edit sea() output for used event years #187

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@ Changes in this release:
 
 * Updated error checking for `+` operator, specifically targeting duplicated series names. (@chguiterman, PR #196)
 
+* Update `sea()` so that only event years that are used are provided in the list output (@chguiterman, #187)
+
 
 # burnr v0.6.1
 

--- a/R/sea.R
+++ b/R/sea.R
@@ -265,7 +265,7 @@ sea <- function(x, event, nbefore = 6, nafter = 4, event_range = TRUE,
   departure_table <- round(departure_table, 3)
 
   out <- list(
-    "event_years" = event,
+    "event_years" = event.cut, # report only used event years
     "actual" = actual_event_table,
     "random" = rand_event_table,
     "departure" = departure_table,


### PR DESCRIPTION
In some cases, `sea()` will drop event years if they do not match a year in the climate series. The function issues a warning and prints the range of years included in the analysis. This PR follows that by only providing the event years used in the function in the `sea` object created by `sea()`

Close #187 